### PR TITLE
Error when playing gifs/mp4 with mpv

### DIFF
--- a/ttrv/templates/mailcap
+++ b/ttrv/templates/mailcap
@@ -32,10 +32,10 @@ image/*; feh -g 640x480 -. '%s'; test=test -n "$DISPLAY"
 # Youtube videos are assigned a custom mime-type, which can be streamed with
 # vlc or youtube-dl.
 video/x-youtube; vlc '%s' --width 640 --height 480; test=test -n "$DISPLAY"
-video/x-youtube; mpv --ytdl-format=bestvideo+bestaudio/best '%s' --autofit 640x480; test=test -n "$DISPLAY"
+video/x-youtube; mpv --ytdl-format=bestvideo+bestaudio/best '%s' --autofit=640x480; test=test -n "$DISPLAY"
 
 # Mpv is a simple and effective video streamer
-video/*; mpv '%s' --autofit 640x480 --loop=inf; test=test -n "$DISPLAY"
+video/*; mpv '%s' --autofit=640x480 --loop=inf; test=test -n "$DISPLAY"
 
 ###############################################################################
 # Commands below this point will attempt to display media directly in the


### PR DESCRIPTION
Playing gifs/youtube videos/mp4 with mpv results to error 'Program exited with status 1'. Fixed issue by adding `=` between autofit parameter and value.