### PR TITLE
Fix MacOS and python 3.8 crash.

### DIFF
--- a/ttrv/terminal.py
+++ b/ttrv/terminal.py
@@ -39,6 +39,9 @@ except ImportError:
     from six.moves import html_parser
     unescape = html_parser.HTMLParser().unescape
 
+if sys.version_info[0:2] == (3, 8) and sys.platform == 'darwin':
+    from multiprocessing import set_start_method
+    set_start_method('fork')
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Based on that post https://github.com/michael-lazar/rtv/issues/710#issuecomment-577910822
on python 3.8 for MacOS the spawn start method is now the default.

I add a check at the beginning of terminal module that check if the OS is MacOS and the python version is 3.8 to set the start method back to `fork`.

Here is the open issue for that bug https://github.com/tildeclub/ttrv/issues/5