### PR TITLE
fixed python3.9 crash on browser load

### DIFF
--- a/ttrv/terminal.py
+++ b/ttrv/terminal.py
@@ -39,7 +39,7 @@ except ImportError:
     from six.moves import html_parser
     unescape = html_parser.HTMLParser().unescape
 
-if sys.version_info[0:2] == (3, 8) and sys.platform == 'darwin':
+if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform == 'darwin':
     from multiprocessing import set_start_method
     set_start_method('fork')
 


### PR DESCRIPTION
The spawn start process method is default on Python >3.8. Checks for python >3.8 and reverts to fork method. 

Fix for https://github.com/tildeclub/ttrv/issues/20 